### PR TITLE
Resolve oauth_token_not_found error in pre-built SDK recipe

### DIFF
--- a/pages/authenticate.tsx
+++ b/pages/authenticate.tsx
@@ -22,13 +22,13 @@ const Authenticate = () => {
         session_duration_minutes: 30,
       });
     }
-  });
+  }, [router, stytch]);
 
   useEffect(() => {
-    if (process.browser && user) {
+    if (typeof window && user) {
       router.replace('/profile');
     }
-  });
+  }, [router, user]);
 
   return null;
 };


### PR DESCRIPTION
This change resolves an error that was printed to browser console in the Pre-built UI + JavaScript SDK recipe. The `useEffect` call which authenticated the tokens did not have a dependency array which was causing ` stytch.oauth.authenticate` to get called multiple times with the same token. Updating the dependency array solves this issue.

Took this opportunity to update the other `useEffect` responsible for doing the redirect.