### PR TITLE
[WEB-2139] demo top nav

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -6,23 +6,63 @@ import Link from 'next/link';
 function NavBar() {
   return (
     <div style={styles.container}>
-      <div style={styles.logoContainer}>
-        <Link href={'/'}>
-          <Image alt="Stytch logo" height={30} src={stytchLogo} width={152} />
-        </Link>
+      <div style={styles.leftNav}>
+        <div style={styles.logoContainer}>
+          <Link href={'/'}>
+            <Image alt="Stytch logo" height={30} src={stytchLogo} width={152} />
+          </Link>
+        </div>
+        <div style={styles.leftLinks}>
+          <a className="no-underline" href="https://stytch.com" rel="noopener noreferrer" target="_blank">
+            Stytch.com
+          </a>
+          <a className="no-underline" href="https://stytch.com/docs" rel="noopener noreferrer" target="_blank">
+            Documentation
+          </a>
+          <a
+            className="no-underline"
+            href="https://github.com/stytchauth/stytch-nextjs-integration"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Github
+          </a>
+          <a
+            className="no-underline"
+            href="https://stytch.com/docs/api/postman"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Postman
+          </a>
+        </div>
       </div>
 
-      <div style={styles.linkContainer}>
+      <div style={styles.rightLinks}>
+        <a className="no-underline" href="https://stytch.com/contact" rel="noopener noreferrer" target="_blank">
+          Contact Us
+        </a>
         <a
           className="no-underline"
-          href="https://github.com/stytchauth/stytch-nextjs-integration"
+          style={styles.secondaryButton}
+          href="https://stytch.com/pricing"
           rel="noopener noreferrer"
           target="_blank"
+          onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = '#ADBCC5')} // cement
+          onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = '#E5E8EB')} // fog
         >
-          View on Github
+          See pricing
         </a>
-        <a className="no-underline" href="https://stytch.com/docs" rel="noopener noreferrer" target="_blank">
-          Stytch Docs
+        <a
+          className="no-underline"
+          style={styles.primaryButton}
+          href="https://stytch.com/dashboard"
+          rel="noopener noreferrer"
+          target="_blank"
+          onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = '#5C727D')} // slate
+          onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = '#19303D')} // charcoal
+        >
+          Get API keys
         </a>
       </div>
     </div>
@@ -33,22 +73,44 @@ const styles: Record<string, React.CSSProperties> = {
   container: {
     display: 'flex',
     alignItems: 'center',
-    backgroundColor: '#c7f1ff',
+    backgroundColor: 'white',
     top: 0,
     justifyContent: 'space-between',
     padding: '16px 16px',
   },
+  leftNav: {
+    display: 'flex',
+    alignItems: 'center',
+  },
   logoContainer: {
     display: 'flex',
     alignItems: 'center',
+    paddingRight: '32px',
   },
   logoFont: {
     padding: '0px 0px 10px 20px',
     fontSize: '30px',
   },
-  linkContainer: {
+  leftLinks: {
     display: 'flex',
     gap: '16px',
+  },
+  rightLinks: {
+    display: 'flex',
+    gap: '16px',
+    alignItems: 'center',
+  },
+  primaryButton: {
+    backgroundColor: '#19303D', // charcoal
+    color: 'white',
+    padding: '8px 22px',
+    borderRadius: '3px',
+  },
+  secondaryButton: {
+    backgroundColor: '#E5E8EB', // fog
+    color: '#19303D', // charcoal
+    padding: '8px 22px',
+    borderRadius: '3px',
   },
   link: {
     fontSize: '20px',

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -4,6 +4,10 @@ import stytchLogo from '/public/stytch-logo.svg';
 import Link from 'next/link';
 
 function NavBar() {
+  const [windowInnerWidth, setWindowInnerWidth] = React.useState<number>(window.innerWidth);
+  addEventListener('resize', () => {
+    setWindowInnerWidth(window.innerWidth);
+  });
   return (
     <div style={styles.container}>
       <div style={styles.leftNav}>
@@ -12,36 +16,40 @@ function NavBar() {
             <Image alt="Stytch logo" height={30} src={stytchLogo} width={152} />
           </Link>
         </div>
-        <div style={styles.leftLinks}>
-          <a className="no-underline" href="https://stytch.com" rel="noopener noreferrer" target="_blank">
-            Stytch.com
-          </a>
-          <a className="no-underline" href="https://stytch.com/docs" rel="noopener noreferrer" target="_blank">
-            Documentation
-          </a>
-          <a
-            className="no-underline"
-            href="https://github.com/stytchauth/stytch-nextjs-integration"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Github
-          </a>
-          <a
-            className="no-underline"
-            href="https://stytch.com/docs/api/postman"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Postman
-          </a>
-        </div>
+        {windowInnerWidth > 1000 && (
+          <div style={styles.leftLinks}>
+            <a className="no-underline" href="https://stytch.com" rel="noopener noreferrer" target="_blank">
+              Stytch.com
+            </a>
+            <a className="no-underline" href="https://stytch.com/docs" rel="noopener noreferrer" target="_blank">
+              Documentation
+            </a>
+            <a
+              className="no-underline"
+              href="https://github.com/stytchauth/stytch-nextjs-integration"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Github
+            </a>
+            <a
+              className="no-underline"
+              href="https://stytch.com/docs/api/postman"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Postman
+            </a>
+          </div>
+        )}
       </div>
 
       <div style={styles.rightLinks}>
-        <a className="no-underline" href="https://stytch.com/contact" rel="noopener noreferrer" target="_blank">
-          Contact Us
-        </a>
+        {windowInnerWidth > 600 && (
+          <a className="no-underline" href="https://stytch.com/contact" rel="noopener noreferrer" target="_blank">
+            Contact Us
+          </a>
+        )}
         <a
           className="no-underline"
           style={styles.secondaryButton}

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -4,10 +4,18 @@ import stytchLogo from '/public/stytch-logo.svg';
 import Link from 'next/link';
 
 function NavBar() {
-  const [windowInnerWidth, setWindowInnerWidth] = React.useState<number>(window.innerWidth);
-  addEventListener('resize', () => {
-    setWindowInnerWidth(window.innerWidth);
-  });
+  const [windowInnerWidth, setWindowInnerWidth] = React.useState<number>(0);
+
+  React.useEffect(() => {
+    const handleWindowResize = () => {
+      setWindowInnerWidth(window.innerWidth);
+    };
+    handleWindowResize();
+    window.addEventListener('resize', handleWindowResize);
+    // unsubscribe from the event on component unmount
+    return () => window.removeEventListener('resize', handleWindowResize);
+  }, []);
+
   return (
     <div style={styles.container}>
       <div style={styles.leftNav}>

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -149,7 +149,6 @@ const styles: Record<string, React.CSSProperties> = {
     borderRadius: '3px',
   },
   secondaryButton: {
-    backgroundColor: '#E5E8EB', // fog
     color: '#19303D', // charcoal
     padding: '8px 22px',
     borderRadius: '3px',

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -26,10 +26,22 @@ function NavBar() {
         </div>
         {windowInnerWidth > 1000 && (
           <div style={styles.leftLinks}>
-            <a className="no-underline" href="https://stytch.com" rel="noopener noreferrer" target="_blank">
+            <a
+              className="no-underline"
+              style={styles.leftLinkText}
+              href="https://stytch.com"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               Stytch.com
             </a>
-            <a className="no-underline" href="https://stytch.com/docs" rel="noopener noreferrer" target="_blank">
+            <a
+              className="no-underline"
+              style={styles.leftLinkText}
+              href="https://stytch.com/docs"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               Documentation
             </a>
             <a
@@ -37,11 +49,13 @@ function NavBar() {
               href="https://github.com/stytchauth/stytch-nextjs-integration"
               rel="noopener noreferrer"
               target="_blank"
+              style={styles.leftLinkText}
             >
               Github
             </a>
             <a
               className="no-underline"
+              style={styles.leftLinkText}
               href="https://stytch.com/docs/api/postman"
               rel="noopener noreferrer"
               target="_blank"
@@ -54,7 +68,15 @@ function NavBar() {
 
       <div style={styles.rightLinks}>
         {windowInnerWidth > 600 && (
-          <a className="no-underline" href="https://stytch.com/contact" rel="noopener noreferrer" target="_blank">
+          <a
+            className="no-underline"
+            style={styles.tertiaryButton}
+            href="https://stytch.com/contact"
+            rel="noopener noreferrer"
+            target="_blank"
+            onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = '#E5E8EB')} // fog
+            onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'white')}
+          >
             Contact Us
           </a>
         )}
@@ -102,6 +124,7 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex',
     alignItems: 'center',
     paddingRight: '32px',
+    cursor: 'pointer',
   },
   logoFont: {
     padding: '0px 0px 10px 20px',
@@ -110,6 +133,10 @@ const styles: Record<string, React.CSSProperties> = {
   leftLinks: {
     display: 'flex',
     gap: '16px',
+  },
+  leftLinkText: {
+    fontSize: '16px',
+    fontWeight: 500,
   },
   rightLinks: {
     display: 'flex',
@@ -124,6 +151,11 @@ const styles: Record<string, React.CSSProperties> = {
   },
   secondaryButton: {
     backgroundColor: '#E5E8EB', // fog
+    color: '#19303D', // charcoal
+    padding: '8px 22px',
+    borderRadius: '3px',
+  },
+  tertiaryButton: {
     color: '#19303D', // charcoal
     padding: '8px 22px',
     borderRadius: '3px',

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -12,7 +12,6 @@ function NavBar() {
     };
     handleWindowResize();
     window.addEventListener('resize', handleWindowResize);
-    // unsubscribe from the event on component unmount
     return () => window.removeEventListener('resize', handleWindowResize);
   }, []);
 
@@ -86,8 +85,8 @@ function NavBar() {
           href="https://stytch.com/pricing"
           rel="noopener noreferrer"
           target="_blank"
-          onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = '#ADBCC5')} // cement
-          onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = '#E5E8EB')} // fog
+          onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = '#E5E8EB')} // fog
+          onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'white')}
         >
           See pricing
         </a>
@@ -154,6 +153,7 @@ const styles: Record<string, React.CSSProperties> = {
     color: '#19303D', // charcoal
     padding: '8px 22px',
     borderRadius: '3px',
+    border: '1px solid #19303D', // charcoal
   },
   tertiaryButton: {
     color: '#19303D', // charcoal


### PR DESCRIPTION
Fixed demo top nav to look like the Figma: https://www.figma.com/design/qBLLLwbJYGeZoca4m3lQD4/Onboarding-|-Q2-2024-|-HM?node-id=599-11503&m=dev

As the screen gets smaller, I progressively remove certain links. Dark mode does not change the background or text color (this is the pattern we are following for our marketing site).