### PR TITLE
Upgrade Stytch versions for SIWE

### DIFF
--- a/lib/recipeData.tsx
+++ b/lib/recipeData.tsx
@@ -90,7 +90,7 @@ await stytchClient.magicLinks.authenticate(token as string);`,
     details:
       'Our Web3 login products let you seamlessly weave crypto wallets into your traditional Web2 app or your latest Web3 project.',
     description: `In this example you can link your Ethereum based wallet with Stytch with just a few clicks!`,
-    instructions: `To the right you'll see button to sign in with your wallet, once clicked your wallet will open a prompt to get started. Below you can see the four simple steps to authenticate an Ethereum wallet; fetch the address, generate a challenge, sign the challenge, validate the signature with Stytch.`,
+    instructions: `To the right you'll see a button to sign in with your wallet. Once clicked, your wallet will open a prompt to get started. Below you can see the four simple steps to authenticate an Ethereum wallet: fetch the address, generate a challenge, sign the challenge, and validate the signature with Stytch. If you want to use the Sign In With Ethereum (SIWE) protocol for Ethereum crypto wallet logins, you'll need to toggle "Enable SIWE" in the SDK Configuration page of your dashboard.`,
     component: <LoginWithCryptoWallets />,
     products: [LoginProducts.WEB3],
     code: `

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@github/webauthn-json": "^2.0.1",
-        "@stytch/nextjs": "^18.0.0",
-        "@stytch/vanilla-js": "^4.8.0",
+        "@stytch/nextjs": "^20.3.3",
+        "@stytch/vanilla-js": "^4.18.1",
         "cookies": "^0.8.0",
         "next": "^12.3.1",
         "react": "^18.2.0",
@@ -370,30 +370,42 @@
       "dev": true
     },
     "node_modules/@stytch/core": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@stytch/core/-/core-2.12.0.tgz",
-      "integrity": "sha512-0DyEv2D38EU4MH7kxNic05w/r99X2yNfSRrh2hNnLDciN7/w/rjSn2VTicFkSd87KIiydS3iMZQNwVo2mLzPuw==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@stytch/core/-/core-2.23.0.tgz",
+      "integrity": "sha512-+Id0/ud93urlTpiWg+5+DNqXUInbDcQFlmN9n2o8SPdUtsETkDGI3bfTkrzfRYE205tu1LlfRAm/FrP4tTIPNA==",
       "dependencies": {
         "uuid": "8.3.2"
       }
     },
     "node_modules/@stytch/nextjs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@stytch/nextjs/-/nextjs-18.0.0.tgz",
-      "integrity": "sha512-8maWCqL/zRe73WSSX0x4v51AP6lUBw2p9XHrDce4g4HwjyCOOdjdnBu3c9AgxQJuHfuBC1xldtp5+eft9SdCyw==",
+      "version": "20.3.3",
+      "resolved": "https://registry.npmjs.org/@stytch/nextjs/-/nextjs-20.3.3.tgz",
+      "integrity": "sha512-Ne1a2fviK2Jtj+0XUISfzKZZ1fOQMxPCmVZ6AUn4UmiYST/IoNXe3ucsppjZRDdTSAvOGLaC0AaKkVtm97eYew==",
       "peerDependencies": {
-        "@stytch/vanilla-js": "^4.7.0",
+        "@stytch/vanilla-js": "^4.16.0",
         "react": ">= 17.0.2",
         "react-dom": ">= 17.0.2"
       }
     },
     "node_modules/@stytch/vanilla-js": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@stytch/vanilla-js/-/vanilla-js-4.8.0.tgz",
-      "integrity": "sha512-5Wru4Ve9IoFKk8KqJPU7mv2DWRvxGep04+6H95ll8fJFohWR4aZYsomWX4ezr049Rkq8yhecFU0GVKvlipbABQ==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@stytch/vanilla-js/-/vanilla-js-4.18.1.tgz",
+      "integrity": "sha512-UKK1fihOooQA0xOkTGCUrq8BJhmDPxt4P6y4lHsI9BK3fhycKElv51BsfvhaXw69WSL+0lRCO0iTNyee+TT+Eg==",
       "dependencies": {
-        "@stytch/core": "2.12.0",
-        "@types/google-one-tap": "^1.2.0"
+        "@stytch/core": "2.23.0",
+        "@types/google-one-tap": "^1.2.0",
+        "type-fest": "4.15.0"
+      }
+    },
+    "node_modules/@stytch/vanilla-js/node_modules/type-fest": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.15.0.tgz",
+      "integrity": "sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@swc/helpers": {
@@ -3894,26 +3906,34 @@
       "dev": true
     },
     "@stytch/core": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@stytch/core/-/core-2.12.0.tgz",
-      "integrity": "sha512-0DyEv2D38EU4MH7kxNic05w/r99X2yNfSRrh2hNnLDciN7/w/rjSn2VTicFkSd87KIiydS3iMZQNwVo2mLzPuw==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@stytch/core/-/core-2.23.0.tgz",
+      "integrity": "sha512-+Id0/ud93urlTpiWg+5+DNqXUInbDcQFlmN9n2o8SPdUtsETkDGI3bfTkrzfRYE205tu1LlfRAm/FrP4tTIPNA==",
       "requires": {
         "uuid": "8.3.2"
       }
     },
     "@stytch/nextjs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@stytch/nextjs/-/nextjs-18.0.0.tgz",
-      "integrity": "sha512-8maWCqL/zRe73WSSX0x4v51AP6lUBw2p9XHrDce4g4HwjyCOOdjdnBu3c9AgxQJuHfuBC1xldtp5+eft9SdCyw==",
+      "version": "20.3.3",
+      "resolved": "https://registry.npmjs.org/@stytch/nextjs/-/nextjs-20.3.3.tgz",
+      "integrity": "sha512-Ne1a2fviK2Jtj+0XUISfzKZZ1fOQMxPCmVZ6AUn4UmiYST/IoNXe3ucsppjZRDdTSAvOGLaC0AaKkVtm97eYew==",
       "requires": {}
     },
     "@stytch/vanilla-js": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@stytch/vanilla-js/-/vanilla-js-4.8.0.tgz",
-      "integrity": "sha512-5Wru4Ve9IoFKk8KqJPU7mv2DWRvxGep04+6H95ll8fJFohWR4aZYsomWX4ezr049Rkq8yhecFU0GVKvlipbABQ==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@stytch/vanilla-js/-/vanilla-js-4.18.1.tgz",
+      "integrity": "sha512-UKK1fihOooQA0xOkTGCUrq8BJhmDPxt4P6y4lHsI9BK3fhycKElv51BsfvhaXw69WSL+0lRCO0iTNyee+TT+Eg==",
       "requires": {
-        "@stytch/core": "2.12.0",
-        "@types/google-one-tap": "^1.2.0"
+        "@stytch/core": "2.23.0",
+        "@types/google-one-tap": "^1.2.0",
+        "type-fest": "4.15.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "4.15.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.15.0.tgz",
+          "integrity": "sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA=="
+        }
       }
     },
     "@swc/helpers": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   ],
   "dependencies": {
     "@github/webauthn-json": "^2.0.1",
-    "@stytch/nextjs": "^18.0.0",
-    "@stytch/vanilla-js": "^4.8.0",
+    "@stytch/nextjs": "^20.3.3",
+    "@stytch/vanilla-js": "^4.18.1",
     "cookies": "^0.8.0",
     "next": "^12.3.1",
     "react": "^18.2.0",


### PR DESCRIPTION
Now that SIWE is released, we can use it for the crypto wallets flow in our demo app! No configuration needed - we just need to toggle "SIWE enabled" in the SDK configuration for the project powering the hosted demo. This PR bumps the `@stytch/vanilla-js` and `@stytch/nextjs` versions to pick up the SIWE changes.

I looked through the changelogs and I'm pretty sure this won't break anything - I don't think there were actually any breaking changes to `nextjs`. I poked around a couple of the other recipes besides crypto wallets to make sure they still worked.