### PR TITLE
Add remembered device flow recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,17 @@ cp .env.template .env.local
 # Replace your keys in new .env.local file
 ```
 
-Next we'll configure the appropriate redirect URLs for your project, you'll set these magic link URLs for your project in the [Redirect URLs](https://stytch.com/dashboard/redirect-urls) section of your Dashboard. Add `http://localhost:3000/authenticate` as both a login and sign-up redirect URL. If you'd like to try our [WebAuthn](https://stytch.com/docs/api/webauthn-overview) example integration, add `http://localhost:3000/recipes/api-webauthn/magic-link-authenticate` as a login and sign-up redirect URL as well.
+Next we'll configure the appropriate redirect URLs for your project, you'll set these magic link URLs for your project in the [Redirect URLs](https://stytch.com/dashboard/redirect-urls) section of your Dashboard. 
+
+* Add `http://localhost:3000/authenticate` as both a login and sign-up redirect URL. 
+
+* If you'd like to try our [WebAuthn](https://stytch.com/docs/api/webauthn-overview) example integration, add `http://localhost:3000/recipes/api-webauthn/magic-link-authenticate` as a login and sign-up redirect URL as well.
+
+* If you'd like to try our SMS OTP example integration, add `http://localhost:3000/recipes/api-sms-mfa/magic-link-authenticate` as a login and sign-up redirect URL.
+
+* If you'd like to try our Remember Device example integration:
+  * Add `http://localhost:3000/recipes/api-sms-remembered-device/magic-link-authenticate` as a login and sign-up redirect URL.
+  * [Request access](https://offers.stytch.com/dfp-30-day-trial) to [our Device Fingerprinting product](https://stytch.com/docs/fraud/guides) if you don't have it already!
 
 ## Running the example app
 

--- a/components/EmailSMS/LoginWithEmailRememberedDevice.tsx
+++ b/components/EmailSMS/LoginWithEmailRememberedDevice.tsx
@@ -1,0 +1,126 @@
+import React, { ChangeEventHandler, FormEventHandler, useState } from 'react';
+import { sendEML } from '../../lib/emlUtils';
+
+const STATUS = {
+  INIT: 0,
+  SENT: 1,
+  ERROR: 2,
+};
+
+const EML_REDIRECT = '/recipes/api-sms-remembered-device/magic-link-authenticate';
+
+const LoginWithSMSMFA = () => {
+  const [emlSent, setEMLSent] = useState(STATUS.INIT);
+  const [email, setEmail] = useState('');
+  const [isDisabled, setIsDisabled] = useState(true);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const isValidEmail = (emailValue: string) => {
+    // Overly simple email address regex
+    const regex = /\S+@\S+\.\S+/;
+    return regex.test(emailValue);
+  };
+
+  const onEmailChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    setEmail(e.target.value);
+    setIsDisabled(!isValidEmail(e.target.value));
+  };
+
+  const onSubmit: FormEventHandler = async (e) => {
+    e.preventDefault();
+    // Disable button right away to prevent sending emails twice
+    if (isDisabled) {
+      return;
+    }
+    setIsDisabled(true);
+
+    if (isValidEmail(email)) {
+      try {
+        const resp = await sendEML(email, EML_REDIRECT, EML_REDIRECT);
+        if (resp.status === 200) {
+          setEMLSent(STATUS.SENT);
+        } else {
+          // Try to get the error message from the response
+          const errorData = await resp.json().catch(() => ({ errorString: 'Unknown error occurred' }));
+          setEMLSent(STATUS.ERROR);
+          
+          // The errorString contains the full Stytch error object as a string
+          try {
+            const stytchError = JSON.parse(errorData.errorString);
+            setErrorMessage("error: " + stytchError.error_type || 'Failed to send email');
+          } catch (parseError) {
+            setErrorMessage('Failed to send email');
+          }
+        }
+      } catch (error) {
+        setEMLSent(STATUS.ERROR);
+        setErrorMessage(error instanceof Error ? error.message : 'Failed to send email');
+      }
+    }
+  };
+
+  const handleTryAgain = (e: any) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setEMLSent(STATUS.INIT);
+    setEmail('');
+    setErrorMessage('');
+  };
+
+  return (
+    <>
+      {emlSent === STATUS.INIT && (
+        <div>
+          <h2>Sign up or log in</h2>
+          <p>
+            Make sure to add the appropriate Redirect URL in your{' '}
+            <a className="link" href="https://stytch.com/dashboard/redirect-urls" target="_blank" rel="noreferrer">
+              Stytch Dashboard
+            </a>
+            .
+          </p>
+          <form onSubmit={onSubmit}>
+            <input
+              style={styles.emailInput}
+              placeholder="example@email.com"
+              value={email}
+              onChange={onEmailChange}
+              type="email"
+            />
+            <button className="full-width" disabled={isDisabled} id="button" type="submit">
+              Continue
+            </button>
+          </form>
+        </div>
+      )}
+      {emlSent === STATUS.SENT && (
+        <div>
+          <h2>Check your email</h2>
+          <p>{`An email was sent to ${email}`}</p>
+          <a className="link" onClick={handleTryAgain}>
+            Click here to try again.
+          </a>
+        </div>
+      )}
+      {emlSent === STATUS.ERROR && (
+        <div>
+          <h2>Something went wrong!</h2>
+          <p>{errorMessage || `Failed to send email to ${email}`}</p>
+          <a className="link" onClick={handleTryAgain}>
+            Click here to try again.
+          </a>
+        </div>
+      )}
+    </>
+  );
+};
+
+const styles: Record<string, React.CSSProperties> = {
+  emailInput: {
+    width: '100%',
+    fontSize: '18px',
+    marginBottom: '8px',
+  },
+};
+
+export default LoginWithSMSMFA;

--- a/components/EmailSMS/SMSOTPButtonRememberedDevice.tsx
+++ b/components/EmailSMS/SMSOTPButtonRememberedDevice.tsx
@@ -1,0 +1,166 @@
+import React, { useState } from 'react';
+import { sendOTP, authOTP } from '../../lib/otpUtilsRememberedDevice';
+import { useRouter } from 'next/router';
+
+interface SMSOTPButtonProps {
+  phoneNumber: string;
+}
+
+function formatPhoneNumber(phoneNumber: string): string {
+  const cleaned = phoneNumber.replace(/\D/g, '').replace(/^1/, '');
+  const match = cleaned.match(/^(\d{3})(\d{3})(\d{4})$/);
+  if (match) {
+    return `(${match[1]}) ${match[2]}-${match[3]}`;
+  }
+  return phoneNumber;
+}
+
+function SMSOTPButton({ phoneNumber }: SMSOTPButtonProps) {
+  const router = useRouter();
+  const [openModal, setOpenModal] = useState(false); // State variable to control the modal visibility
+  const [otp, setOTP] = useState(''); // State variable to store the OTP input by the user
+  const [methodId, setMethodId] = useState(''); // State variable to store the method ID
+
+  const authenticate = async () => {
+    try {
+      const response = await sendOTP(phoneNumber);
+
+      // Check if response is empty
+      if (!response) {
+        console.error('Empty response received from sendOTP');
+        return;
+      }
+  
+      const responseData = await response;
+      setMethodId(responseData.phone_id);
+      
+      // Set state to open the modal
+      setOpenModal(true);
+
+    } catch (error) {
+      // Handle errors here, e.g., display an error message
+      console.error('Failed to send OTP:', error);
+    }
+  };
+
+  const handleModalClose = () => {
+    // Clear OTP input and close the modal
+    setOTP('');
+    setOpenModal(false);
+  };
+
+  const handleOTPSubmit = async () => {
+    try {
+      // Call the authOTP function with methodID and otp
+      console.log('METHOD', methodId);
+      await authOTP(methodId, otp);
+
+      // Redirect to profile page
+      router.push('./profile');
+    } catch (error) {
+      // Handle errors here, e.g., display an error message
+      console.error('Failed to authenticate OTP:', error);
+    }
+  };
+
+  const handleResend = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+    e.preventDefault();
+    authenticate();
+  };
+
+  return (
+    <div>
+      <button className="full-width" onClick={authenticate}>
+        Authenticate
+      </button>
+      
+      {/* Modal for OTP input */}
+      {openModal && (
+        <div style={styles.modalOverlay}>
+          <div style={styles.modal}>
+            <span style={styles.close} onClick={handleModalClose}>&times;</span>
+            <h2>Enter Passcode</h2>
+            <p>
+              A 6-digit passcode was sent to you at <strong>{formatPhoneNumber(phoneNumber)}</strong>.
+            </p>
+            <input
+              style={styles.otpInput}
+              type="text"
+              value={otp}
+              onChange={(e) => setOTP(e.target.value)}
+              placeholder="Enter OTP"
+            />
+            <p style={styles.smsDisclaimer}>
+            Didn&apos;t receive a code? <a style={styles.smsDisclaimer} href="#" onClick={handleResend}>Resend</a>
+            </p>
+            <button className="full-width" onClick={handleOTPSubmit}>Submit</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  modalOverlay: {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modal: {
+    position: 'relative',
+    backgroundColor: 'white',
+    padding: 20,
+    borderRadius: '0 3px 3px 0',
+    boxShadow: '0 0 10px rgba(0, 0, 0, 0.2)',
+  },
+  close: {
+    position: 'absolute',
+    top: 10,
+    right: 18,
+    cursor: 'pointer',
+  },
+  telInput: {
+    display: 'flex',
+    alignItems: 'center',
+    border: '1px solid #ccc', 
+    borderRadius: '3px', 
+    marginBottom: '10px', 
+  },
+  flag: {
+    background: 'url("/stars-and-stripes.png") no-repeat scroll 8px 16px',
+    paddingLeft: 40,
+    borderRadius: 0,
+    width: 75,
+    border: 'none', 
+  },
+  phoneNumber: {
+    border: 'none',
+    paddingLeft: 10,
+    fontSize: 18,
+    flexGrow: 1,
+    width: 'calc(100%)',
+  },
+  smsDisclaimer: {
+    color: '#5c727d',
+    fontSize: 14,
+    marginBottom: 16,
+    marginTop: 15,
+  },
+  otpInput: {
+    display: 'flex',
+    alignItems: 'center',
+    border: '1px solid #ccc', 
+    borderRadius: '3px', 
+    marginBottom: '10px', 
+    width: '100%', 
+  }  
+};
+
+export default SMSOTPButton; 

--- a/components/EmailSMS/SMSRegisterRememberedDevice.tsx
+++ b/components/EmailSMS/SMSRegisterRememberedDevice.tsx
@@ -1,0 +1,184 @@
+import React, { useState } from 'react';
+import { sendOTP, authOTP } from '../../lib/otpUtilsRememberedDevice';
+import { useRouter } from 'next/router';
+
+
+function formatPhoneNumber(phoneNumber: string): string {
+  const cleaned = phoneNumber.replace(/\D/g, '').replace(/^1/, '');
+  const match = cleaned.match(/^(\d{3})(\d{3})(\d{4})$/);
+  if (match) {
+    return `(${match[1]}) ${match[2]}-${match[3]}`;
+  }
+  return phoneNumber;
+}
+
+function SMSRegister() {
+  const router = useRouter();
+  const [openModalPhone, setOpenModalPhone] = useState(false);
+  const [openModal, setOpenModal] = useState(false);
+  const [otp, setOTP] = useState('');
+  const [phoneNumber, setPhoneNumber] = useState('');
+  const [methodId, setMethodId] = useState('');
+
+  const phoneModalOpen = async () => {
+    setOpenModalPhone(true);
+  };
+
+  const handlePhoneModalClose = () => {
+    setOpenModalPhone(false);
+  };
+
+  const handleOTPModalClose = () => {
+    setOTP('');
+    setOpenModal(false);
+  };
+
+  const handleOTPSubmit = async () => {
+    try {
+      await authOTP(methodId, otp);
+      router.push('./profile');
+    } catch (error) {
+      console.error('Failed to authenticate OTP:', error);
+    }
+  };
+
+  const handlePhoneSubmit = async () => {
+    try {
+      const response = await sendOTP('+1' + phoneNumber);
+
+      if (!response) {
+        console.error('Empty response received from sendOTP');
+        return;
+      }
+  
+      const responseData = await response;
+      setMethodId(responseData.phone_id);
+
+      setOpenModalPhone(false);
+      setOpenModal(true);
+    } catch (error) {
+      console.error('Failed to send OTP:', error);
+    }
+  };
+
+  return (
+    <div>
+      <button className="full-width" onClick={phoneModalOpen}>
+        Register
+      </button>
+      
+      {/* Modal for phone number input */}
+      {openModalPhone && (
+        <div style={styles.modalOverlay}>
+          <div style={styles.modal}>
+            <span style={styles.close} onClick={handlePhoneModalClose}>&times;</span>
+            <h2>Enter phone number</h2>
+            <p>Enter your phone number to receive a passcode for authentication.</p>
+            <div style={styles.telInput}>
+              <input style={styles.flag} name="intlCode" type="text" value="+1" readOnly />
+              <input
+                style={styles.phoneNumber}
+                type="text"
+                value={phoneNumber}
+                onChange={(e) => setPhoneNumber(e.target.value)}
+                placeholder="(123) 456-7890"
+              />
+            </div>
+            <p style={styles.smsDisclaimer}>
+              By continuing, you consent to receive an SMS for verification. Message and data rates may apply.
+            </p>
+            <button className="full-width" onClick={handlePhoneSubmit}>Submit</button>
+          </div>
+        </div>
+      )}
+
+      {/* Modal for OTP input */}
+      {openModal && (
+        <div style={styles.modalOverlay}>
+          <div style={styles.modal}>
+            <span style={styles.close} onClick={handleOTPModalClose}>&times;</span>
+            <h2>Enter Passcode</h2>
+            <p>
+              A 6-digit passcode was sent to you at <strong>{formatPhoneNumber(phoneNumber)}</strong>.
+            </p>
+            <input
+              style={styles.otpInput}
+              type="text"
+              value={otp}
+              onChange={(e) => setOTP(e.target.value)}
+              placeholder="Enter OTP"
+            />
+            <p style={styles.smsDisclaimer}>
+              Didn&apos;t receive a code? <a style={styles.smsDisclaimer} href="#" onClick={(e) => { e.preventDefault(); handlePhoneSubmit(); }}>Resend</a>
+            </p>
+            <button className="full-width" onClick={handleOTPSubmit}>Submit</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  modalOverlay: {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modal: {
+    position: 'relative',
+    backgroundColor: 'white',
+    padding: 20,
+    borderRadius: '0 3px 3px 0',
+    boxShadow: '0 0 10px rgba(0, 0, 0, 0.2)',
+  },
+  close: {
+    position: 'absolute',
+    top: 10,
+    right: 18,
+    cursor: 'pointer',
+  },
+  telInput: {
+    display: 'flex',
+    alignItems: 'center',
+    border: '1px solid #ccc', 
+    borderRadius: '3px', 
+    marginBottom: '10px', 
+  },
+  flag: {
+    background: 'url("/stars-and-stripes.png") no-repeat scroll 8px 16px',
+    paddingLeft: 40,
+    borderRadius: 0,
+    width: 75,
+    border: 'none', 
+  },
+  phoneNumber: {
+    border: 'none',
+    paddingLeft: 10,
+    fontSize: 18,
+    flexGrow: 1,
+    width: 'calc(100%)',
+  },
+  smsDisclaimer: {
+    color: '#5c727d',
+    fontSize: 14,
+    marginBottom: 16,
+    marginTop: 15,
+  },
+  otpInput: {
+    display: 'flex',
+    alignItems: 'center',
+    border: '1px solid #ccc', 
+    borderRadius: '3px', 
+    marginBottom: '10px', 
+    width: '100%', 
+  }  
+};
+
+export default SMSRegister; 

--- a/lib/otpUtilsRememberedDevice.ts
+++ b/lib/otpUtilsRememberedDevice.ts
@@ -1,10 +1,20 @@
 export async function sendOTP(phoneNumber: string) {
-  const resp = await fetch('/api/send_otp', {
+  const url = '/api/send_otp_remembered_device';
+  console.log('Making request to:', url);
+  console.log('Request body:', { phoneNumber });
+  
+  const resp = await fetch(url, {
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify({
       phoneNumber,
     }),
   });
+  
+  console.log('Response status:', resp.status);
+  console.log('Response headers:', Object.fromEntries(resp.headers.entries()));
   // Check if response status is ok
   if (!resp.ok) {
     const errorText = await resp.text();
@@ -21,11 +31,14 @@ export async function sendOTP(phoneNumber: string) {
 }
 
 export async function authOTP(method_id: string, otp_code: string) {
-  return fetch('/api/authenticate_otp', {
+  return fetch('/api/authenticate_otp_remembered_device', {
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify({
       method_id,
       otp_code,
     }),
   });
-}
+} 

--- a/lib/recipeData.tsx
+++ b/lib/recipeData.tsx
@@ -8,6 +8,7 @@ import LoginProducts from './loginProduct';
 import LoginWithOneTap from '../components/LoginWithOneTapSDKUI';
 import LoginWithPasskeys from "../components/Passkeys/LoginWithPasskeys";
 import LoginWithSMSMFA from '../components/EmailSMS/LoginWithEmail';
+import LoginWithEmailRememberedDevice from '../components/EmailSMS/LoginWithEmailRememberedDevice';
 import {OTPMethods, Products, StytchLoginConfig} from "@stytch/vanilla-js";
 
 export const Recipes: Record<string, LoginType> = {
@@ -83,6 +84,24 @@ await stytchClient.magicLinks.email.loginOrCreate({
   
 // Authenticate the Email magic link
 await stytchClient.magicLinks.authenticate(token as string);`,
+  },
+  REMEMBERED_DEVICE: {
+    id: 'remembered-device',
+    title: 'Remembered Device',
+    details: 'Build a remembered device authentication flow using Stytch DFP.',
+    description: 'In this example we use a backend Stytch auth flow and DFP to build a remembered device/location authentication flow. In this example a login attempt from the same country is considered a known device/location, but you can get more granular by using something like visitor_finterprint or IP address.',
+    instructions: 'To the right you\'ll see a login form that uses Stytch telemetry to remember your device. Enter your email to receive a magic link. The first time you login, you will be prompted to register SMS OTP as a second factor. On subsequent logins, you will only be prompted to authenticate with SMS OTP if you are attempting to authenticate from a new location.',
+    component: <LoginWithEmailRememberedDevice />,
+    code: `// Send EML normally
+await sendEML(
+  email,
+  '/recipes/api-sms-remembered-device/magic-link-authenticate',
+  '/recipes/api-sms-remembered-device/magic-link-authenticate'
+);
+
+// Backend handles telemetry and remembered device logic
+// in /api/authenticate_eml endpoint`,
+    products: [LoginProducts.EML, LoginProducts.SMS],
   },
   CRYPTO_WALLETS: {
     id: 'sdk-crypto-wallets',
@@ -232,7 +251,6 @@ const LoginWithOneTap = () => <StytchLogin config={sdkConfig} callbacks={callbac
     // Authenticate the Email magic link
     await stytchClient.magicLinks.authenticate(token as string);`,
   },
-
   FEEDBACK: {
     id: 'feedback',
     title: 'Feedback',

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "next": "^12.3.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "stytch": "^11.4.1"
+        "stytch": "^12.25.0"
       },
       "devDependencies": {
         "@types/cookies": "^0.7.7",
@@ -3411,9 +3411,9 @@
       }
     },
     "node_modules/stytch": {
-      "version": "11.4.1",
-      "resolved": "https://registry.npmjs.org/stytch/-/stytch-11.4.1.tgz",
-      "integrity": "sha512-Qsy20OK2I4tMIvEZWdaidCBiPovqdoQ/L0ivaLArdIJzT5V/UB0Mn3Mow9c8wu8Py8zb5+xM0aFAK0bCQugFNA==",
+      "version": "12.25.0",
+      "resolved": "https://registry.npmjs.org/stytch/-/stytch-12.25.0.tgz",
+      "integrity": "sha512-6WEKKztHf3oTNbJeo8KsEANP8ZjNbL4lIksRvbDAUJAWzNQBkirzw6VKql0Y7eUW1ghsvHgQ/cbue9hBISOyRw==",
       "dependencies": {
         "jose": "^5.6.3",
         "undici": "^6.19.5"
@@ -6083,9 +6083,9 @@
       "requires": {}
     },
     "stytch": {
-      "version": "11.4.1",
-      "resolved": "https://registry.npmjs.org/stytch/-/stytch-11.4.1.tgz",
-      "integrity": "sha512-Qsy20OK2I4tMIvEZWdaidCBiPovqdoQ/L0ivaLArdIJzT5V/UB0Mn3Mow9c8wu8Py8zb5+xM0aFAK0bCQugFNA==",
+      "version": "12.25.0",
+      "resolved": "https://registry.npmjs.org/stytch/-/stytch-12.25.0.tgz",
+      "integrity": "sha512-6WEKKztHf3oTNbJeo8KsEANP8ZjNbL4lIksRvbDAUJAWzNQBkirzw6VKql0Y7eUW1ghsvHgQ/cbue9hBISOyRw==",
       "requires": {
         "jose": "^5.6.3",
         "undici": "^6.19.5"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "next": "^12.3.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "stytch": "^11.4.1"
+    "stytch": "^12.25.0"
   },
   "devDependencies": {
     "@types/cookies": "^0.7.7",

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -17,6 +17,7 @@ class MyDocument extends Document {
             rel="stylesheet"
           />
           <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&display=swap" rel="stylesheet" />
+          <script src="https://elements.stytch.com/telemetry.js"></script>
         </Head>
         <body>
           <Main />

--- a/pages/api/authenticate_eml_remembered_device.ts
+++ b/pages/api/authenticate_eml_remembered_device.ts
@@ -1,0 +1,116 @@
+// This API route authenticates magic link tokens and handles remembered device logic
+import type { NextApiRequest, NextApiResponse } from 'next';
+import loadStytch from '../../lib/loadStytch';
+
+type ErrorData = {
+  errorString: string;
+};
+
+type SuccessData = {
+  session_token: string;
+  user_id: string;
+  country: string;
+  super_secret_data?: string;
+};
+
+export async function handler(req: NextApiRequest, res: NextApiResponse<ErrorData | SuccessData>) {
+  if (req.method === 'POST') {
+    const stytchClient = loadStytch();
+    const { token } = req.body;
+
+    if (!token) {
+      return res.status(400).json({ errorString: 'No token provided' });
+    }
+
+    try {
+      // First, authenticate the magic link token (without claims initially)
+      let authenticateResponse = await stytchClient.magicLinks.authenticate({
+        token: token,
+        session_duration_minutes: 30,
+      });
+      
+      console.log('Authenticate response:', authenticateResponse);
+
+      let knownCountries = authenticateResponse.user.trusted_metadata?.known_countries || [];
+
+      // Get telemetry ID from the request (this would come from the frontend)
+      const telemetryId = req.headers['x-telemetry-id'] as string;
+
+      console.log('telemetryId', telemetryId);
+      
+      let requiresMfa = false;
+      let country = '';
+
+      if (telemetryId) {
+        try {
+          // Lookup the telemetry ID response to get the country
+          const fingerprintResponse = await stytchClient.fraud.fingerprint.lookup({
+            telemetry_id: telemetryId,
+          });
+
+          console.log('Fingerprint response:', fingerprintResponse);
+          
+          country = fingerprintResponse.properties?.network_properties.ip_geolocation.country || '';
+          
+          // Check if the country is in the known countries list
+          if (isKnownCountry(country, knownCountries) && country !== '') {
+            console.log('Country is known, no MFA required');
+            requiresMfa = false;
+            // Update session with custom claims to mark this session as authorized
+            await stytchClient.sessions.authenticate({
+              session_token: authenticateResponse.session_token,
+              session_custom_claims: {
+                authorized_for_secret_data: true,
+                authorized_country: country,
+              },
+            });
+          } else {
+            console.log('Country is not known, MFA required');
+            requiresMfa = true;
+            // Store country in trusted metadata for later retrieval during OTP auth
+            // Store pending country in session custom claims instead of user metadata
+            await stytchClient.sessions.authenticate({
+              session_token: authenticateResponse.session_token,
+              session_custom_claims: {
+                authorized_for_secret_data: false,
+                pending_country: country,
+              },
+            });
+          }
+        } catch (telemetryError) {
+          console.error('Error checking remembered device:', telemetryError);
+          // If telemetry check fails, require MFA for security
+          requiresMfa = true;
+        }
+      } else {
+        // No telemetry ID provided, require MFA to fail closed.
+        requiresMfa = true;
+      }
+
+
+
+      // Set the session cookie in the response
+      res.setHeader('Set-Cookie', `api_sms_remembered_device_session=${authenticateResponse.session_token}; HttpOnly; Path=/; Max-Age=1800; SameSite=Lax`);
+
+      return res.status(200).json({
+        session_token: authenticateResponse.session_token,
+        country: country,
+        user_id: authenticateResponse.user_id,
+        super_secret_data: !requiresMfa ? "Welcome to the super secret data area! You're accessing this area because your device was recognized as a trusted device. No additional MFA was required." : undefined,
+      });
+
+    } catch (error) {
+      const errorString = JSON.stringify(error);
+      console.log(error);
+      return res.status(400).json({ errorString });
+    }
+  } else {
+    return res.status(405).end();
+  }
+}
+
+function isKnownCountry(country: string, knownCountries: string[]) {
+  return knownCountries.includes(country);
+}
+
+export default handler; 

--- a/pages/api/authenticate_otp_remembered_device.ts
+++ b/pages/api/authenticate_otp_remembered_device.ts
@@ -1,0 +1,92 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getDomainFromRequest } from '../../lib/urlUtils';
+import loadStytch from '../../lib/loadStytch';
+import Cookies from 'cookies';
+
+type ErrorData = {
+  errorString: string;
+};
+
+export async function handler(req: NextApiRequest, res: NextApiResponse<ErrorData>) {
+// Get session from cookie - using the recipe-specific cookie name
+  const cookies = new Cookies(req, res);
+  const storedSession = cookies.get('api_sms_remembered_device_session');
+  // If session does not exist display an error
+  if (!storedSession) {
+    return res.status(400).json({ errorString: 'No session provided' });
+  }
+  if (req.method === 'POST') {
+    const stytchClient = loadStytch();
+    // req.body is already parsed by Next.js when Content-Type is application/json
+    const data = req.body;
+
+    try {
+      const { session_token } = await stytchClient.otps.authenticate({
+        method_id: data.method_id,
+        code: data.otp_code,
+        session_token: storedSession
+      });
+
+      // Save updated Stytch session to a cookie - using the recipe-specific cookie name
+      cookies.set('api_sms_remembered_device_session', session_token, {
+        httpOnly: true,
+        maxAge: 1000 * 60 * 30,
+      });
+
+      // Now that MFA is complete, update the trusted metadata
+      // Get the updated session to verify factors
+      const { session: updatedSession } = await stytchClient.sessions.authenticate({ session_token });
+      
+      // Verify that the session has both EML and SMS factors (proving MFA completion)
+      const hasEmailFactor = updatedSession.authentication_factors.some(f => f.delivery_method === 'email');
+      const hasSmsFactor = updatedSession.authentication_factors.some(f => f.delivery_method === 'sms');
+      
+      if (hasEmailFactor && hasSmsFactor) {
+        // Get the pending country from session custom claims that was stored during EML authentication
+        const pendingCountry = updatedSession.custom_claims?.pending_country;
+        
+        if (pendingCountry) {
+          // Get existing known countries or initialize empty array
+          const user = await stytchClient.users.get({ user_id: updatedSession.user_id });
+          const existingKnownCountries = user.trusted_metadata?.known_countries || [];
+          
+          // Add new country if it's not already in the list
+          if (!existingKnownCountries.includes(pendingCountry)) {
+            const updatedKnownCountries = [...existingKnownCountries, pendingCountry];
+
+            // Update the user's trusted metadata with the new known country
+            await stytchClient.users.update({
+              user_id: updatedSession.user_id,
+              trusted_metadata: {
+                ...user.trusted_metadata,
+                known_countries: updatedKnownCountries,
+              },
+            });
+
+            // Update session custom claims to authorize this session for secret data and remove pending country
+            await stytchClient.sessions.authenticate({
+              session_token: session_token,
+              session_custom_claims: {
+                authorized_for_secret_data: true,
+                authorized_country: pendingCountry,
+                pending_country: null, // Remove the pending country from session claims
+              },
+            });
+
+            console.log(`Added country ${pendingCountry} to trusted metadata for user ${updatedSession.user_id} and authorized session`);
+          }
+        }
+      }
+
+      return res.status(200).end();
+    } catch (error) {
+      const errorString = JSON.stringify(error);
+      console.log(error);
+      return res.status(400).json({ errorString });
+    }
+  } else {
+    return res.status(405).json({ errorString: 'Method Not Allowed' });
+  }
+}
+
+export default handler; 

--- a/pages/api/send_otp_remembered_device.ts
+++ b/pages/api/send_otp_remembered_device.ts
@@ -1,0 +1,62 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getDomainFromRequest } from '../../lib/urlUtils';
+import loadStytch from '../../lib/loadStytch';
+import Cookies from 'cookies';
+
+type Data = {
+    phone_id: string;
+    request_id: string;
+    status_code: number;
+    user_id: string;
+};
+
+type ErrorData = {
+  errorString: string;
+};
+
+export async function handler(req: NextApiRequest, res: NextApiResponse<Data | ErrorData>) {
+    // Get session from cookie - using the recipe-specific cookie name
+  const cookies = new Cookies(req, res);
+  const storedSession = cookies.get('api_sms_remembered_device_session');
+  
+  // Debug logging
+  console.log('Request method:', req.method);
+  console.log('Request headers:', req.headers);
+  console.log('Request body type:', typeof req.body);
+  console.log('Request body:', req.body);
+  
+  // If session does not exist display an error
+  if (!storedSession) {
+    return res.status(400).json({ errorString: 'No session provided' });
+  }
+
+  if (req.method === 'POST') {
+    const stytchClient = loadStytch();
+    // req.body is already parsed by Next.js when Content-Type is application/json
+    const data = req.body;
+
+    try {
+      // Check if phoneNumber is present in request body
+      if (!data.phoneNumber) {
+        return res.status(400).json({ errorString: 'Phone number is missing in the request body' });
+      }
+
+      const authResp = await stytchClient.otps.sms.send({
+        phone_number: data.phoneNumber,
+        expiration_minutes: 10,
+        session_token: storedSession
+      });
+
+      return res.status(200).json(authResp);
+    } catch (error) {
+        const errorString = JSON.stringify(error);
+        console.log(error);
+        return res.status(400).json({ errorString });
+    }
+  } else {
+    // Handle other HTTP methods
+    return res.status(405).json({ errorString: 'Method Not Allowed' });
+  }
+}
+
+export default handler; 

--- a/pages/api/update_trusted_metadata.ts
+++ b/pages/api/update_trusted_metadata.ts
@@ -1,0 +1,80 @@
+// This API route updates the user's trusted metadata with new country information
+// Only works if user has completed both EML and SMS authentication
+import type { NextApiRequest, NextApiResponse } from 'next';
+import loadStytch from '../../lib/loadStytch';
+import Cookies from 'cookies';
+
+type ErrorData = {
+  errorString: string;
+};
+
+type SuccessData = {
+  success: boolean;
+};
+
+export async function handler(req: NextApiRequest, res: NextApiResponse<ErrorData | SuccessData>) {
+  if (req.method === 'POST') {
+    const stytchClient = loadStytch();
+
+    try {
+      // Get session from cookie
+      const cookies = new Cookies(req, res);
+      const storedSession = cookies.get('api_sms_remembered_device_session');
+
+      if (!storedSession) {
+        return res.status(401).json({ errorString: 'No session found' });
+      }
+
+      // Authenticate the session to get user ID and verify factors
+      const { session } = await stytchClient.sessions.authenticate({ session_token: storedSession });
+      
+      // Verify that the session has both EML and SMS factors (proving MFA completion)
+      const hasEmailFactor = session.authentication_factors.some(f => f.delivery_method === 'email');
+      const hasSmsFactor = session.authentication_factors.some(f => f.delivery_method === 'sms');
+      
+      if (!hasEmailFactor || !hasSmsFactor) {
+        return res.status(403).json({ errorString: 'MFA not completed. Both email and SMS factors required.' });
+      }
+
+      // Get the pending country from session custom claims that was stored during EML authentication
+      const pendingCountry = session.custom_claims?.pending_country;
+      
+      if (!pendingCountry) {
+        return res.status(400).json({ errorString: 'No pending country found for this session' });
+      }
+      
+      // Get user to access existing trusted metadata
+      const user = await stytchClient.users.get({ user_id: session.user_id });
+      
+      // Get existing known countries or initialize empty array
+      const existingKnownCountries = user.trusted_metadata?.known_countries || [];
+      
+      // Add new country if it's not already in the list
+      if (!existingKnownCountries.includes(pendingCountry)) {
+        const updatedKnownCountries = [...existingKnownCountries, pendingCountry];
+
+        // Update the user's trusted metadata and clean up pending country
+        await stytchClient.users.update({
+          user_id: session.user_id,
+          trusted_metadata: {
+            ...user.trusted_metadata,
+            known_countries: updatedKnownCountries,
+            pending_country: undefined, // Remove the pending country
+          },
+        });
+
+        console.log(`Added country ${pendingCountry} to trusted metadata for user ${session.user_id}`);
+      }
+
+      return res.status(200).json({ success: true });
+    } catch (error) {
+      const errorString = JSON.stringify(error);
+      console.log(error);
+      return res.status(400).json({ errorString });
+    }
+  } else {
+    return res.status(405).end();
+  }
+}
+
+export default handler; 

--- a/pages/recipes/api-sms-remembered-device/magic-link-authenticate.tsx
+++ b/pages/recipes/api-sms-remembered-device/magic-link-authenticate.tsx
@@ -1,0 +1,127 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useEffect, useState, useRef } from 'react';
+
+type Props = {
+  token?: string;
+};
+
+const AuthenticateMagicLink = ({ token }: Props) => {
+  const router = useRouter();
+  const [status, setStatus] = useState<'loading' | 'error' | 'requiresMfa' | 'success'>('loading');
+  const [error, setError] = useState<string>('');
+  const hasAuthenticated = useRef(false);
+
+  const authenticateWithTelemetry = async () => {
+    if (!token) {
+      setError('No magic link token present.');
+      setStatus('error');
+      return;
+    }
+
+    try {
+      // Get telemetry ID from the Stytch script
+      let telemetryId: string | undefined;
+      
+      try {
+        const publicToken = process.env.NEXT_PUBLIC_STYTCH_PUBLIC_TOKEN;
+        telemetryId = await (window as any).GetTelemetryID({ publicToken });
+      } catch (telemetryError) {
+        console.warn('Could not get telemetry ID:', telemetryError);
+      }
+      
+      // Call our authenticate API
+      const response = await fetch('/api/authenticate_eml_remembered_device', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(telemetryId && { 'X-Telemetry-ID': telemetryId }),
+        },
+        body: JSON.stringify({ token }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        setError(errorData.errorString);
+        setStatus('error');
+        return;
+      }
+
+      const data = await response.json();
+
+      // The backend has already set the session cookie, so we can redirect
+      // MFA requirement is determined by session state, not response data
+      if (data.country) {
+        // Redirect to profile with country info (MFA requirement determined by session)
+        router.push(`./profile?country=${encodeURIComponent(data.country)}`);
+      } else {
+        // Redirect to profile (authorization determined by session)
+        router.push('./profile');
+      }
+    } catch (error) {
+      setError(JSON.stringify(error));
+      setStatus('error');
+    }
+  };
+
+  useEffect(() => {
+    if (token && !hasAuthenticated.current) {
+      hasAuthenticated.current = true;
+      authenticateWithTelemetry();
+    }
+  }, [token]);
+
+  if (status === 'loading') {
+    return (
+      <div>
+        <h2>Authenticating...</h2>
+        <p>Please wait while we verify your device.</p>
+      </div>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <div>
+        <p>{`Error: ${error}`}</p>
+        <Link href="../../recipes/remembered-device">
+          <a className="link">Click here to start over</a>
+        </Link>
+      </div>
+    );
+  }
+
+  if (status === 'requiresMfa') {
+    return (
+      <div>
+        <h2>Additional Authentication Required</h2>
+        <p>This appears to be a new device. Please complete SMS verification to continue.</p>
+        <Link href="./profile">
+          <a className="link">Continue to Profile</a>
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h2>Welcome back!</h2>
+      <p>Your device has been recognized. You can now access your profile.</p>
+      <Link href="./profile">
+        <a className="link">Continue to Profile</a>
+      </Link>
+    </div>
+  );
+};
+
+export const getServerSideProps = async (context: any) => {
+  const token = context.query.token;
+  
+  if (!token) {
+    return { props: { error: 'No magic link token present.' } };
+  }
+
+  return { props: { token } };
+};
+
+export default AuthenticateMagicLink;

--- a/pages/recipes/api-sms-remembered-device/profile.tsx
+++ b/pages/recipes/api-sms-remembered-device/profile.tsx
@@ -1,0 +1,202 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { useRouter } from 'next/router';
+import { GetServerSideProps } from 'next/types';
+import loadStytch from '../../../lib/loadStytch';
+import Cookies from 'cookies';
+import lock from '/public/lock.svg';
+import CodeBlock from '../../../components/common/CodeBlock';
+import SMSOTPButton from '../../../components/EmailSMS/SMSOTPButtonRememberedDevice';
+import SMSRegister from '../../../components/EmailSMS/SMSRegisterRememberedDevice';
+
+type Props = {
+  user?: Object;
+  session?: Object;
+  error?: string;
+  hasRegisteredPhone?: boolean;
+  superSecretData?: string;
+  phoneNumber?: string;
+  isRememberedDevice?: boolean;
+  requiresMfa?: boolean;
+  country?: string;
+};
+
+const Profile = ({ error, user, session, hasRegisteredPhone, superSecretData, phoneNumber, isRememberedDevice, requiresMfa, country }: Props) => {
+  const router = useRouter();
+
+  if (error) {
+    return (
+      <div>
+        <p>{`Error: ${error}`}</p>
+        <Link href="/">
+          <a className="link">Click here to start over</a>
+        </Link>
+      </div>
+    );
+  }
+
+  const signOut = async () => {
+    try {
+      const resp = await fetch('/api/logout', { method: 'POST' });
+      if (resp.status === 200) {
+        router.push('/');
+      }
+    } catch {}
+  };
+
+
+
+  if (!user) {
+    return <></>;
+  }
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.details}>
+        <h2>Welcome to your profile!</h2>
+
+        <div style={styles.secretBox}>
+          <h3>Super secret area</h3>
+          {superSecretData ? (
+            <div>
+              <p>{superSecretData}</p>
+              {isRememberedDevice && (
+                <p style={styles.rememberedDeviceNote}>
+                  🎉 <strong>Device location remembered!</strong> You bypassed MFA because this device location was recognized.
+                </p>
+              )}
+            </div>
+          ) : (
+            <>
+              <Image alt="Lock" src={lock} width={100} />
+              <p>
+                {requiresMfa 
+                  ? `Additional authentication required. This appears to be a new location (${country || 'unknown country'}). Please complete SMS verification to continue.`
+                  : 'Super secret profile information is secured by two factor authentication. To unlock this area complete the SMS OTP flow.'
+                }
+              </p>
+              {hasRegisteredPhone && phoneNumber ? (
+                <SMSOTPButton phoneNumber={phoneNumber} />
+              ) : (
+                <SMSRegister />
+              )}
+            </>
+          )}
+        </div>
+
+        <button onClick={signOut}>Sign out</button>
+      </div>
+      <div style={styles.details}>
+        <h2>Stytch objects</h2>
+
+        <h3>Session</h3>
+        <CodeBlock codeString={JSON.stringify(session, null, 2).replace(' ', '')} />
+        <h3>User</h3>
+        <CodeBlock codeString={JSON.stringify(user, null, 2).replace(' ', '')} />
+      </div>
+    </div>
+  );
+};
+
+const styles: Record<string, React.CSSProperties> = {
+  container: {
+    display: 'flex',
+    margin: '48px 24px',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: '48px',
+  },
+  details: {
+    backgroundColor: '#FFF',
+    padding: '48px',
+    flexBasis: '900px',
+    flexGrow: 1,
+  },
+  secretBox: {
+    display: 'flex',
+    backgroundColor: '#ecfaff',
+    flexGrow: '1',
+    flexDirection: 'column',
+    margin: '50px 0px',
+    alignItems: 'center',
+    padding: '8px 24px',
+  },
+  rememberedDeviceNote: {
+    backgroundColor: '#d4edda',
+    color: '#155724',
+    padding: '10px',
+    borderRadius: '4px',
+    marginTop: '10px',
+    textAlign: 'center',
+  },
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const cookies = new Cookies(context.req, context.res);
+  const storedSession = cookies.get('api_sms_remembered_device_session');
+
+  if (!storedSession) {
+    return { props: { error: 'No user session found.' } };
+  }
+
+  try {
+    const stytchClient = loadStytch();
+
+    // Get the session data (this doesn't consume the token)
+    const { session } = await stytchClient.sessions.authenticate({ session_token: storedSession });
+
+    const user = await stytchClient.users.get({ user_id: session.user_id });
+
+    const hasRegisteredPhone = user.phone_numbers.length > 0;
+
+    const phoneNumber = user.phone_numbers[0]?.phone_number ?? '';
+
+    let superSecretData = null;
+    let isRememberedDevice = false;
+    let requiresMfa = true; // Default to requiring MFA unless session proves otherwise
+    let country = '';
+
+    // Get the state from query parameters (set by the authenticate_eml_remembered_device endpoint)
+    const countryParam = context.query.country as string || '';
+
+    // Server-side authorization check based on session authentication factors and custom claims
+    const hasEmailFactor = session.authentication_factors.find((i: any) => i.delivery_method === 'email');
+    const hasSmsFactor = session.authentication_factors.find((i: any) => i.delivery_method === 'sms');
+    
+    if (hasEmailFactor && hasSmsFactor) {
+      // User has completed full MFA - authorized for super secret data
+      superSecretData =
+        "Welcome to the super secret data area. If you inspect your Stytch session on the right you will see you have two authentication factors: email and phone. You're only able to view the Super secret area because your session has both of these authentication factors.";
+      requiresMfa = false;
+    } else if (hasEmailFactor && session.custom_claims?.authorized_for_secret_data) {
+      // User is in a remembered device location (authorized during EML auth via session claims)
+      superSecretData =
+        "Welcome to the super secret data area! You're accessing this area because your device was recognized as a trusted device. No additional MFA was required.";
+      isRememberedDevice = true;
+      requiresMfa = false;
+      country = session.custom_claims.authorized_country as string || '';
+    } else {
+      // User needs MFA - either no email factor or not in trusted location
+      requiresMfa = true;
+      country = session.custom_claims?.pending_country as string || '';
+    }
+
+    // Due to Date serialization issues in Next we do some fancy JSON translations
+    return {
+      props: {
+        user: JSON.parse(JSON.stringify(user)),
+        session: JSON.parse(JSON.stringify(session)),
+        hasRegisteredPhone,
+        phoneNumber,
+        superSecretData,
+        isRememberedDevice,
+        requiresMfa,
+        country,
+      },
+    };
+  } catch (error) {
+    return { props: { error: JSON.stringify(error) } };
+  }
+};
+
+export default Profile;

--- a/pages/recipes/api-sms-remembered-device/sms-register.ts
+++ b/pages/recipes/api-sms-remembered-device/sms-register.ts
@@ -1,0 +1,3 @@
+import LoginWithSMS from '../../../components/EmailSMS/LoginWithEmail';
+
+export { LoginWithSMS as default };


### PR DESCRIPTION
Draft to add a recipe for a remembered device flow using DFP. 

Rather than try and make some of the existing components/api endpoints extensible (take dynamic redirect URLs, dynamic cookie names, etc.) I just created dedicated components and endpoints for this flow. 

It's more (boilerplate) code, but IMO dedicated components/endpoints/etc that are obviously for this recipe make it clearer to follow, and in the context of a recipe book the goal is clarity and not code reuse/optimization. 